### PR TITLE
Fixed time compression bug & tweaks

### DIFF
--- a/TediousTravelControllMenu.cs
+++ b/TediousTravelControllMenu.cs
@@ -191,7 +191,7 @@ namespace TediousTravel
         {
             if (timeCompressionSetting < 5)
                 timeCompressionSetting += 1;
-            else timeCompressionSetting = Math.Min(25, timeCompressionSetting + 5);
+            else timeCompressionSetting = Math.Min(100, timeCompressionSetting + 5);
             timeCompressionTextbox.Text = timeCompressionSetting.ToString() + "x";
             RaiseOnTimeCompressionChangedEvent(timeCompressionSetting);
         }

--- a/TediousTravelMap.cs
+++ b/TediousTravelMap.cs
@@ -1339,12 +1339,11 @@ namespace TediousTravel
 
             if (GameManager.Instance.PlayerEntity.GoldPieces < tripCost)
             {
-                DaggerfallMessageBox noMoneyMessageBox = new DaggerfallMessageBox(
-                    uiManager,
-                    DaggerfallMessageBox.CommonMessageBoxButtons.Nothing,
-                    "Unfortunately you do not have the " + tripCost + " gold pieces required for the " + days + " days journey");
-                noMoneyMessageBox.ClickAnywhereToClose = true;
-                noMoneyMessageBox.Show();
+                DaggerfallUI.MessageBox(new string[]
+                {
+                    "Unfortunately you do not have the " + tripCost + " gold",
+                    "   pieces required for the " + days + " days journey."
+                });
             }
             else
             {


### PR DESCRIPTION
- When changing time scale, the fixed time interval has to be changed as well otherwise the fixed updates (physics etc) are getting called far too much. (up to 25x50 per second! PlayerMotor has a FixedUpdate and that's what was crippling framerate)
- Clear destination string when loading or starting a game. (I assumed it was a bug)
- Raised max time multiplier from 25 to 100. (now that performance is much improved - see forums)
- Changed a couple of message box uses to demonstrate some shortcut helper functions, and also show how to get text to span multiple lines.