### PR TITLE
use OnEncounter event

### DIFF
--- a/TediousTravel.cs
+++ b/TediousTravel.cs
@@ -43,7 +43,7 @@ namespace TediousTravel
 		private readonly float delayCombatTime = 100.0f;
 
 		public static Mod mod;
-        private bool enemiesNearby = false;
+        private bool encounter = false;
 
         private void Start()
         {
@@ -147,7 +147,7 @@ namespace TediousTravel
                 if (!travelUi.isShowing)
                 {
                     DaggerfallUI.UIManager.PushWindow(travelUi);
-                    enemiesNearby = false;
+                    encounter = false;
                     GameManager.OnEncounter += GameManager_OnEncounter;
                 }
 
@@ -155,10 +155,10 @@ namespace TediousTravel
 
 				hudVitals.Update();
 
-				if ((enemiesNearby || GameManager.Instance.AreEnemiesNearby()) && delayCombat <= 0.0f)
+				if ((encounter || GameManager.Instance.AreEnemiesNearby()) && delayCombat <= 0.0f)
 				{
-                    Debug.Log("enemiesNearby = " + enemiesNearby + " AreEnemiesNearby() = " + GameManager.Instance.AreEnemiesNearby());
-                    enemiesNearby = false;
+                    Debug.Log("encounter = " + encounter + " AreEnemiesNearby() = " + GameManager.Instance.AreEnemiesNearby());
+                    encounter = false;
 					if (encounterAvoidanceSystem)
 					{
 						InterruptFastTravel();
@@ -212,7 +212,7 @@ namespace TediousTravel
 
         private void GameManager_OnEncounter()
         {
-            enemiesNearby = true;
+            encounter = true;
         }
 
 

--- a/TediousTravel.cs
+++ b/TediousTravel.cs
@@ -43,8 +43,9 @@ namespace TediousTravel
 		private readonly float delayCombatTime = 100.0f;
 
 		public static Mod mod;
+        private bool enemiesNearby = false;
 
-		private void Start()
+        private void Start()
         {
 			ModSettings settings = mod.GetSettings();
 
@@ -146,14 +147,18 @@ namespace TediousTravel
                 if (!travelUi.isShowing)
                 {
                     DaggerfallUI.UIManager.PushWindow(travelUi);
+                    enemiesNearby = false;
+                    GameManager.OnEncounter += GameManager_OnEncounter;
                 }
 
                 playerAutopilot.Update();
 
 				hudVitals.Update();
 
-				if (GameManager.Instance.AreEnemiesNearby() && delayCombat <= 0.0f)
+				if ((enemiesNearby || GameManager.Instance.AreEnemiesNearby()) && delayCombat <= 0.0f)
 				{
+                    Debug.Log("enemiesNearby = " + enemiesNearby + " AreEnemiesNearby() = " + GameManager.Instance.AreEnemiesNearby());
+                    enemiesNearby = false;
 					if (encounterAvoidanceSystem)
 					{
 						InterruptFastTravel();
@@ -166,6 +171,7 @@ namespace TediousTravel
 					}
 					else
 					{
+                        GameManager.OnEncounter -= GameManager_OnEncounter;
 						travelUi.CloseWindow();
 						DaggerfallUI.MessageBox("An enemy is seeking to bring a premature end to your journey...");
 						return;
@@ -202,9 +208,15 @@ namespace TediousTravel
 			{
 				travelUi.CloseWindow();
 			}
-		}
+        }
 
-		private bool AttemptAvoid()
+        private void GameManager_OnEncounter()
+        {
+            enemiesNearby = true;
+        }
+
+
+        private bool AttemptAvoid()
 		{
 			int playerSkillRunning = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Running);
 			int playerSkillStealth = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth);


### PR DESCRIPTION
This should make encounters work more reliably at high time compressions.

I just submitted the PR to add that feature to Daggerfall Unity, so it will require the patch to be accepted, and then will only be compatible with newer builds onward.

https://github.com/Interkarma/daggerfall-unity/pull/1318