### PR TITLE
Fix maxSuccessChance in AttemptAvoid()

### DIFF
--- a/TediousTravel.cs
+++ b/TediousTravel.cs
@@ -209,17 +209,12 @@ namespace TediousTravel
 			int playerSkillRunning = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Running);
 			int playerSkillStealth = playerEntity.Skills.GetLiveSkillValue(DFCareer.Skills.Stealth);
 
-			int successChance = playerSkillRunning > playerSkillStealth ? playerSkillRunning : playerSkillStealth;
+			int successChance =  Mathf.Max(playerSkillRunning, playerSkillStealth);
 
 			//Scaled to mod settings
-			successChance = successChance / (100 / maxSuccessChance);
+			successChance = successChance * maxSuccessChance / 100;
 
-			bool tempBool = UnityEngine.Random.Range(0, 101) <= successChance;
-
-			if (tempBool)
-				return true;
-			else
-				return false;
+			return Dice100.SuccessRoll(successChance);
 		}
 
 		public void StartFastTravel(ContentReader.MapSummary destinationSummary)


### PR DESCRIPTION
    successChance = successChance / (100 / maxSuccessChance);

This cannot work because pf integer divisions. Let's take the default value of 80 as an example: 100 / 80 = 1, so

    successChance = successChance / (100 / maxSuccessChance);

becomes successChance = successChance / 1 and does nothing. maxSuccessChance values between 51 and 100 give the same result.

Other changes are more stylistic and are not bug fixes.